### PR TITLE
api redesign

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ julia:
   - 1.1
   - 1.2
   - 1.3
+  - 1.4
   - nightly
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# v0.3.0
+
+- API redesign: take `Order` & `OrdersTo`, return `SVector` [[#5](https://github.com/tpapp/SpectralKit.jl/pull/5)]
+
 # v0.2.0
 
 - re-enable 1.1 support, fix docs links [[#3](https://github.com/tpapp/SpectralKit.jl/pull/3)]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,10 +1,9 @@
 # This file is machine-generated - editing it directly is not advised
 
 [[ArgCheck]]
-deps = ["Random"]
-git-tree-sha1 = "dab25d711a1dedb707a55dbc1eb9fd578f76ff32"
+git-tree-sha1 = "e14de95bcfacd85e00f5369958a38bb72827bce2"
 uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
-version = "1.0.1"
+version = "1.1.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -28,10 +27,15 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -39,18 +43,6 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[[OrderedCollections]]
-deps = ["Random", "Serialization", "Test"]
-git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
-uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.1.0"
-
-[[Parameters]]
-deps = ["OrderedCollections"]
-git-tree-sha1 = "b62b2558efb1eef1fa44e4be5ff58a515c287e38"
-uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-version = "0.12.0"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -77,6 +69,20 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "5a3bcb6233adabde68ebc97be66e95dcb787424c"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.12.1"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -84,6 +90,11 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[UnPack]]
+git-tree-sha1 = "e0cb9715adda456f7657e45377fd3063bf87179a"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "0.1.0"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,14 @@ version = "0.2.0"
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ArgCheck = "^1"
 DocStringExtensions = "^0.8"
-Parameters = "^0.12"
 julia = "^1.1"
+UnPack = "0.1"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,9 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 [compat]
 ArgCheck = "^1"
 DocStringExtensions = "^0.8"
-julia = "^1.1"
+StaticArrays = "0.12"
 UnPack = "0.1"
+julia = "^1.1"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpectralKit"
 uuid = "5c252ae7-b5b6-46ab-a016-b0e3d78320b7"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,7 +31,7 @@ julia> augmented_extrema(F, 5)        # Gauss-Lobatto grid
  1.7071067811865475
  2.0
 
-julia> evaluate(F, 3, 0.41, Val(0))   # value of the 3nd (starting at 1!) polynomial at 0.41
+julia> evaluate(F, 3, 0.41, Val(0))   # value of the 3rd (starting at 1!) polynomial at 0.41
 -0.3037999999999994
 
 julia> evaluate(F, 3, 0.41, Val(0:1)) # value and the derivative

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,16 +31,20 @@ julia> augmented_extrema(F, 5)        # Gauss-Lobatto grid
  1.7071067811865475
  2.0
 
-julia> evaluate(F, 3, 0.41, Val(0))   # value of the 3rd (starting at 1!) polynomial at 0.41
+julia> evaluate(F, 3, 0.41, Order(0))   # value of the 3rd (starting at 1!) polynomial at 0.41
 -0.3037999999999994
 
-julia> evaluate(F, 3, 0.41, Val(0:1)) # value and the derivative
-(-0.3037999999999994, -2.3600000000000008)
+julia> evaluate(F, 3, 0.41, OrdersTo(1)) # value and the derivative
+2-element StaticArrays.SArray{Tuple{2},Float64,1,2} with indices SOneTo(2):
+ -0.3037999999999994
+ -2.3600000000000008
 ```
 
 ## Abstract interface for function families
 
 ```@docs
+Order
+OrdersTo
 is_function_family
 domain_extrema
 evaluate

--- a/src/SpectralKit.jl
+++ b/src/SpectralKit.jl
@@ -5,7 +5,7 @@ export is_function_family, domain_extrema, roots, augmented_extrema, evaluate, C
 
 using ArgCheck: @argcheck
 using DocStringExtensions: FUNCTIONNAME, SIGNATURES, TYPEDEF
-using Parameters: @unpack
+using UnPack: @unpack
 
 ####
 #### utilities


### PR DESCRIPTION
Major API change: 

- orders are now specified using `Order` and `OrdersTo`
- for `OrdersTo`, return `SVector` instead of a tuple (easier to do algebra on it)

Incidental:

- fix typo in docs
- use UnPack instead of Parameters