### PR TITLE
Fix interior grid nesting.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpectralKit"
 uuid = "5c252ae7-b5b6-46ab-a016-b0e3d78320b7"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ Derivatives die out slower than for the [0,∞) transformation.
 With `B = 3`.
 
 <img src="docs/plots/smolyak_grid.png" width="50%">
+
+## Bibliography
+
+- Boyd, J. P. (2001). Chebyshev and fourier spectral methods. Courier Corporation.
+
+- Xu, K. (2016). The chebyshev points of the first kind. Applied Numerical Mathematics, 102, 17–30.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,8 +58,9 @@ Chebyshev
 ### Grid specifications
 
 ```@docs
-InteriorGrid
 EndpointGrid
+InteriorGrid
+InteriorGrid2
 ```
 
 ### Transformations

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -15,18 +15,16 @@ struct Chebyshev{K} <: FunctionBasis
     "The number of basis functions."
     N::Int
     @doc """
-    Chebyshev polynomials (of the first kind) on ``[-1, 1]``.
+    $(SIGNATURES)
+    `N` Chebyshev polynomials (of the first kind) on ``[-1, 1]``, with the associated
+    grid of `grid_kind`.
 
     !!! note
         This is not meant to be used directly as a basis, but as a building block, eg in
         [`univariate_basis`](@ref) and [`smolyak_basis`](@ref).
     """
     function Chebyshev(grid_kind::K, N::Int) where K
-        if grid_kind ≡ EndpointGrid()
-            @argcheck N ≥ 2
-        else
-            @argcheck N ≥ 1
-        end
+        @argcheck N ≥ 1
         new{K}(grid_kind, N)
     end
 end
@@ -80,8 +78,19 @@ end
 function gridpoint(::Type{T}, basis::Chebyshev{EndpointGrid}, i::Integer) where {T <: Real}
     @unpack N = basis
     @argcheck 1 ≤ i ≤ N         # FIXME use boundscheck
-    cospi((N - i) ./ T(N - 1))
+    if N == 1
+        cospi(1/T(2))           # 0.0 as a fallback, even though it does not have endpoints
+    else
+        cospi((N - i) ./ T(N - 1))
+    end
 end
+
+function gridpoint(::Type{T}, basis::Chebyshev{InteriorGrid2}, i::Integer) where {T <: Real}
+    @unpack N = basis
+    @argcheck 1 ≤ i ≤ N         # FIXME use boundscheck
+    cospi(((N - i + 1) ./ T(N + 1)))
+end
+
 
 ####
 #### augmenting

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -74,7 +74,7 @@ end
 function gridpoint(::Type{T}, basis::Chebyshev{InteriorGrid}, i::Integer) where {T <: Real}
     @unpack N = basis
     @argcheck 1 ≤ i ≤ N         # FIXME use boundscheck
-    cospi((2*(N - i) + 1) / T(2 * N))
+    sinpi((N - 2 * i + 1) / T(2 * N)) # use formula Xu (2016)
 end
 
 function gridpoint(::Type{T}, basis::Chebyshev{EndpointGrid}, i::Integer) where {T <: Real}

--- a/src/generic_api.jl
+++ b/src/generic_api.jl
@@ -2,8 +2,8 @@
 ##### Generic API
 #####
 
-export is_function_basis, dimension, domain, basis_at, linear_combination,
-    InteriorGrid, EndpointGrid, grid, collocation_matrix, augment_coefficients,
+export is_function_basis, dimension, domain, basis_at, linear_combination, InteriorGrid,
+    InteriorGrid2, EndpointGrid, grid, collocation_matrix, augment_coefficients,
     is_subset_basis
 
 """
@@ -112,16 +112,29 @@ Grid with interior points (eg Gauss-Chebyshev).
 """
 struct InteriorGrid <: AbstractGrid end
 
-Base.show(io::IO, ::InteriorGrid) = print(io, "interior grid")
+Base.show(io::IO, ::InteriorGrid) = print(io, "interior grid (factor 3)")
 
 """
 $(TYPEDEF)
 
 Grid that includes endpoints (eg Gauss-Lobatto).
+
+!!! note
+    For small dimensions may fall back to a grid that does not contain endpoints.
 """
 struct EndpointGrid <: AbstractGrid end
 
 Base.show(io::IO, ::EndpointGrid) = print(io, "grid w/ endpoints")
+
+"""
+$(TYPEDEF)
+
+Grid with interior points that results in smaller grids than `InteriorGrid` when nested.
+Equivalent to an `EndpointGrid` with endpoints dropped.
+"""
+struct InteriorGrid2 <: AbstractGrid end
+
+Base.show(io::IO, ::InteriorGrid2) = print(io, "interior grid (factor 2)")
 
 """
 $(SIGNATURES)

--- a/src/generic_api.jl
+++ b/src/generic_api.jl
@@ -112,8 +112,6 @@ Grid with interior points (eg Gauss-Chebyshev).
 """
 struct InteriorGrid <: AbstractGrid end
 
-Base.show(io::IO, ::InteriorGrid) = print(io, "interior grid (factor 3)")
-
 """
 $(TYPEDEF)
 
@@ -124,8 +122,6 @@ Grid that includes endpoints (eg Gauss-Lobatto).
 """
 struct EndpointGrid <: AbstractGrid end
 
-Base.show(io::IO, ::EndpointGrid) = print(io, "grid w/ endpoints")
-
 """
 $(TYPEDEF)
 
@@ -133,8 +129,6 @@ Grid with interior points that results in smaller grids than `InteriorGrid` when
 Equivalent to an `EndpointGrid` with endpoints dropped.
 """
 struct InteriorGrid2 <: AbstractGrid end
-
-Base.show(io::IO, ::InteriorGrid2) = print(io, "interior grid (factor 2)")
 
 """
 $(SIGNATURES)

--- a/src/smolyak_api.jl
+++ b/src/smolyak_api.jl
@@ -181,23 +181,23 @@ applied coordinate-wise.
 julia> basis = smolyak_basis(Chebyshev, InteriorGrid(), SmolyakParameters(3),
                              (BoundedLinear(2, 3), SemiInfRational(3.0, 4.0)))
 Sparse multivariate basis on ℝ^2
-  Smolyak indexing, ∑bᵢ ≤ 3, all bᵢ ≤ 3, dimension 29
-  using Chebyshev polynomials (1st kind), interior grid, dimension: 9
+  Smolyak indexing, ∑bᵢ ≤ 3, all bᵢ ≤ 3, dimension 81
+  using Chebyshev polynomials (1st kind), interior grid, dimension: 27
   domain transformations
     (2.0,3.0) [linear transformation]
     (3.0,∞) [rational transformation with scale 4.0]
 
 julia> dimension(basis)
-29
+81
 
 julia> domain(basis)
 ((2.0, 3.0), (3.0, Inf))
+```
 
 ## Properties
 
 *Grids nest*: increasing arguments of `SmolyakParameters` result in a refined grid that
  contains points of the cruder grid.
-```
 """
 function smolyak_basis(univariate_family, grid_kind::AbstractGrid,
                        smolyak_parameters::SmolyakParameters,

--- a/src/smolyak_api.jl
+++ b/src/smolyak_api.jl
@@ -182,7 +182,7 @@ julia> basis = smolyak_basis(Chebyshev, InteriorGrid(), SmolyakParameters(3),
                              (BoundedLinear(2, 3), SemiInfRational(3.0, 4.0)))
 Sparse multivariate basis on ℝ^2
   Smolyak indexing, ∑bᵢ ≤ 3, all bᵢ ≤ 3, dimension 81
-  using Chebyshev polynomials (1st kind), interior grid, dimension: 27
+  using Chebyshev polynomials (1st kind), InteriorGrid(), dimension: 27
   domain transformations
     (2.0,3.0) [linear transformation]
     (3.0,∞) [rational transformation with scale 4.0]

--- a/src/smolyak_api.jl
+++ b/src/smolyak_api.jl
@@ -192,6 +192,11 @@ julia> dimension(basis)
 
 julia> domain(basis)
 ((2.0, 3.0), (3.0, Inf))
+
+## Properties
+
+*Grids nest*: increasing arguments of `SmolyakParameters` result in a refined grid that
+ contains points of the cruder grid.
 ```
 """
 function smolyak_basis(univariate_family, grid_kind::AbstractGrid,

--- a/src/smolyak_traversal.jl
+++ b/src/smolyak_traversal.jl
@@ -3,8 +3,23 @@
 #####
 
 ####
-#### Block sizes and shuffling
+#### Nesting sizes and shuffling
 ####
+
+###
+### nesting grids
+###
+### NOTE: This is not exported as we have no API for nesting univariate bases, only
+### Smolyak. When refactoring, consider exporting with a unified API.
+
+"""
+$(SIGNATURES)
+
+Cumulative block length at block `b`.
+"""
+@inline function nesting_total_length(::Type{Chebyshev}, ::EndpointGrid, b::Int)
+    b == 0 ? 1 : ((1 << b) + 1)
+end
 
 """
 $(SIGNATURES)
@@ -15,14 +30,15 @@ Length of each block `b`.
     Smolyak grids use “blocks” of polynomials, each indexed by ``b == 0, …, B`, with an
     increasing number of points in each.
 """
-@inline __block_length(b::Int) = b ≤ 1 ? b + 1 : 1 << (b - 1)
+@inline function nesting_block_length(::Type{Chebyshev}, ::EndpointGrid, b::Int)
+    b ≤ 1 ? b + 1 : 1 << (b - 1)
+end
 
-"""
-$(SIGNATURES)
+@inline nesting_total_length(::Type{Chebyshev}, ::InteriorGrid, b::Int) = 3^b
 
-Cumulative block length at block `b`.
-"""
-@inline __cumulative_block_length(b::Int) = b == 0 ? 1 : ((1 << b) + 1)
+@inline function nesting_block_length(::Type{Chebyshev}, ::InteriorGrid, b::Int)
+    b == 0 ? 1 : 2 * 3^(b - 1)
+end
 
 """
 $(TYPEDEF)
@@ -30,21 +46,46 @@ $(TYPEDEF)
 An iterator of indices for picking elements from a grid of length `len`, which should be a
 valid cumulative block length.
 """
-struct SmolyakGridShuffle
+struct SmolyakGridShuffle{K}
+    grid_kind::K
     len::Int
 end
 
 Base.length(ι::SmolyakGridShuffle) = ι.len
 
-Base.eltype(::Type{SmolyakGridShuffle}) = Int
+Base.eltype(::Type{<:SmolyakGridShuffle}) = Int
 
-function Base.iterate(ι::SmolyakGridShuffle)
+function Base.iterate(ι::SmolyakGridShuffle{InteriorGrid})
+    @unpack len = ι
+    i0 = (len + 1) ÷ 2          # first index at this level
+    Δ = len                     # basis for step size
+    a = 2                       # alternating as 2Δa and Δa
+    i0, (i0, i0, Δ, a)
+end
+
+function Base.iterate(ι::SmolyakGridShuffle{InteriorGrid}, (i, i0, Δ, a))
+    @unpack len = ι
+    i′ = i + a * Δ
+    if i′ ≤ len
+        i′, (i′, i0, Δ, 3 - a)
+    else
+        if Δ == 1
+            nothing
+        else
+            Δ = Δ ÷ 3
+            i0 -= Δ
+            i0, (i0, i0, Δ, 2)
+        end
+    end
+end
+
+function Base.iterate(ι::SmolyakGridShuffle{EndpointGrid})
     @unpack len = ι
     i = (len + 1) ÷ 2
     i, (0, 0)                   # step = 0 is special-cased
 end
 
-function Base.iterate(ι::SmolyakGridShuffle, (i, step))
+function Base.iterate(ι::SmolyakGridShuffle{EndpointGrid}, (i, step))
     @unpack len = ι
     i == 0 && return len > 1 ? (1, (1, len - 1)) : nothing
     i′ = i + step
@@ -65,6 +106,15 @@ end
 #### index traversal
 ####
 
+function __inc_init(first_block_length, ::Val{N}, ::Val{B}) where {N,B}
+    indices = ntuple(_ -> 1, Val(N))
+    blocks = ntuple(_ -> 0, Val(N))
+    l = first_block_length
+    limits = ntuple(_ -> l, Val(N))
+    slack = B
+    slack, indices, blocks, limits
+end
+
 """
 $(SIGNATURES)
 
@@ -80,7 +130,7 @@ Internal implementation of the Smolyak indexing iterator.
 
 - `blocks`: block indexes
 
-- `limits`: `__cumulative_block_length.(blocks)`, cached
+- `limits`: `nesting_total_length.(Chebyshev, blocks, grid_kind)`
 
 # Return values
 
@@ -92,8 +142,8 @@ Internal implementation of the Smolyak indexing iterator.
 - `indices′`, `blocks′, `limits′`: next values for corresponding arguments above, each an
   `::NTuple{N,Int}`
 """
-@inline function __inc(cumulative_block_lengths::NTuple{M,Int}, slack::Int,
-                       indices::NTuple{N,Int}, blocks::NTuple{N,Int},
+@inline function __inc(first_block_length::Int, cumulative_block_lengths::NTuple{M,Int},
+                       slack::Int, indices::NTuple{N,Int}, blocks::NTuple{N,Int},
                        limits::NTuple{N,Int}) where {M,N}
     i1, iτ... = indices
     b1, bτ... = blocks
@@ -108,19 +158,11 @@ Internal implementation of the Smolyak indexing iterator.
             false, 0, indices, blocks, limits
         else                    # i1 = 1, increment tail if applicable
             Δ1 = b1
-            valid, Δτ, iτ′, bτ′, lτ′ = __inc(cumulative_block_lengths, slack + Δ1, iτ, bτ, lτ)
-            valid, Δ1 + Δτ, (1, iτ′...), (0, bτ′...), (__cumulative_block_length(0), lτ′...)
+            valid, Δτ, iτ′, bτ′, lτ′ = __inc(first_block_length, cumulative_block_lengths,
+                                             slack + Δ1, iτ, bτ, lτ)
+            valid, Δ1 + Δτ, (1, iτ′...), (0, bτ′...), (first_block_length, lτ′...)
         end
     end
-end
-
-function __inc_init(::Val{N}, ::Val{B}) where {N,B}
-    indices = ntuple(_ -> 1, Val(N))
-    blocks = ntuple(_ -> 0, Val(N))
-    l = __cumulative_block_length(0)
-    limits = ntuple(_ -> l, Val(N))
-    slack = B
-    slack, indices, blocks, limits
 end
 
 """
@@ -128,17 +170,18 @@ $(SIGNATURES)
 
 Calculate the length of a [`SmolyakIndices`](@ref) iterator. Argument as in the latter.
 """
-function __smolyak_length(::Val{N}, ::Val{B}, M::Int) where {N,B}
+function __smolyak_length(grid_kind::AbstractGrid, ::Val{N}, ::Val{B}, M::Int) where {N,B}
     # implicit assumption: M ≤ B
+    _bl(b) = nesting_block_length(Chebyshev, grid_kind, b)
     c = zeros(MVector{B+1,Int}) # indexed as 0, …, B
     for b in 0:M
-        c[b + 1] = __block_length(b)
+        c[b + 1] = _bl(b)
     end
     for n in 2:N
         for b in B:(-1):0            # blocks with indices that sum to b
             s = 0
             for a in 0:min(b, M)
-                s += __block_length(a) * c[b - a + 1]
+                s += _bl(a) * c[b - a + 1]
             end
             # can safely overwrite since they will not be used again for n + 1
             c[b + 1] = s

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -68,7 +68,7 @@ The following is a basis with 10 transformed Chebyshev polynomials of the first 
 
 ```jldoctest
 julia> basis = univariate_basis(Chebyshev, InteriorGrid(), 10, SemiInfRational(3.0, 4.0))
-Chebyshev polynomials (1st kind), interior grid, dimension: 10
+Chebyshev polynomials (1st kind), InteriorGrid(), dimension: 10
   domain (3.0,∞) [rational transformation with scale 4.0]
 
 julia> dimension(basis)

--- a/test/test_chebyshev.jl
+++ b/test/test_chebyshev.jl
@@ -4,7 +4,7 @@
 
 @testset "Chebyshev" begin
     @test_throws ArgumentError Chebyshev(InteriorGrid(), 0)
-    @test_throws ArgumentError Chebyshev(EndpointGrid(), 1)
+    @test_throws ArgumentError Chebyshev(EndpointGrid(), 0)
 
     for grid_kind in (InteriorGrid(), EndpointGrid())
         for N in (grid_kind ≡ InteriorGrid() ? 1 : 2):10

--- a/test/test_smolyak.jl
+++ b/test/test_smolyak.jl
@@ -6,9 +6,9 @@ using SpectralKit: nesting_total_length, nesting_block_length, SmolyakIndices,
 ####
 
 @testset "block length" begin
-    for grid_kind in (EndpointGrid(), InteriorGrid)
+    for grid_kind in (EndpointGrid(), InteriorGrid())
         # NOTE starting from 1 as we currently disallow construction with N=0
-        for b in (grid_kind ≡ EndpointGrig() ? 1 : 0):5
+        for b in (grid_kind ≡ EndpointGrid() ? 1 : 0):5
             nA = nesting_total_length(Chebyshev, grid_kind, b)
             gA = grid(Chebyshev(grid_kind, nA))
             gB = grid(Chebyshev(grid_kind, nesting_total_length(Chebyshev, grid_kind, b + 1)))

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -58,6 +58,16 @@ function zero_upto(x::SVector{N,T}, C) where {N,T}
     SVector(y)
 end
 
+"Flags (`true`) for elements in `a` that are within `atol` of some element in `b`."
+function is_approximately_in(a, b; atol = √eps())
+    map(a -> any(b -> maximum(abs.(a .- b)) ≤ atol, b), a)
+end
+
+"Are elements in `a` in `b`, approximately."
+function is_approximate_subset(a, b; atol = √eps())
+    sum(is_approximately_in(a, b; atol = atol)) == length(a)
+end
+
 # """
 # $(SIGNATURES)
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -60,7 +60,9 @@ end
 
 "Flags (`true`) for elements in `a` that are within `atol` of some element in `b`."
 function is_approximately_in(a, b; atol = √eps())
-    map(a -> any(b -> maximum(abs.(a .- b)) ≤ atol, b), a)
+    _same(a::Real, b::Real) = a == b || abs(a - b) ≤ atol # Inf = Inf, etc
+    _same(a::AbstractVector, b::AbstractVector) = all(_same.(a, b))
+    map(a -> any(b -> _same(a, b), b), a)
 end
 
 "Are elements in `a` in `b`, approximately."


### PR DESCRIPTION
- add Xu (2016) to bibliography
- calculate interior gridpoints with `sinpi` (better accuracy)
- use `grid_kind` in Smolyak indices
- cache first block size too
- rename block length functions
- add block length calculations for interior grid
- test for grid nesting