### PR TITLE
redesign partial derivatives API

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -158,10 +158,11 @@ is_subset_basis
 !!! note
     API for derivatives is still experimental and subject to change.
 
-If derivatives along a coordinate are needed, use [`derivatives`](@ref). For multiple coordinates, the result will be nested in the order of increasing tags. When unspecified, tags are assigned automatically from left to right.
+For univariate functions, use [`derivatives`](@ref). For multivariate functions, use partial derivatives with `∂`.
 
 ```@docs
 derivatives
+∂
 ```
 
 ## Internals

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,20 @@
 # SpectralKit
 
-This is a very simple package for *building blocks* of spectral methods. Its intended audience is users who are familiar with the theory and practice of these methods, and prefer to assemble their code from modular building blocks. If you need an introduction, a book like *Boyd (2001): Chebyshev and Fourier spectral methods* is a good place to start.
+This is a very simple package for *building blocks* of spectral methods. Its intended audience is users who are familiar with the theory and practice of these methods, and prefer to assemble their code from modular building blocks, potentially reusing calculations. If you need an introduction, a book like *Boyd (2001): Chebyshev and Fourier spectral methods* is a good place to start.
 
-The package is optimized for solving functional equations, as usually encountered in economics when solving discrete and continuous-time problems. It uses [static arrays](https://github.com/JuliaArrays/StaticArrays.jl) extensively to avoid allocation and unroll *some* loops. Key functionality includes evaluating a set of basis functions, their linear combination at arbitrary points in a fast manner, for use in threaded code. These should work seamlessly with automatic differentiation frameworks, but also has its own primitives for obtaining derivatives of basis functions.
+This package was designed primarily for solving functional equations, as usually encountered in economics when solving discrete and continuous-time problems. Key features include
 
-## Introduction
+1. evaluation of univariate and multivatiate basis functions, including Smolyak combinations,
+2. transformed to the relevant domains of interest, eg ``[a,b] × [0,∞)``,
+3. (partial) derivatives, with correct limits at endpoints,
+4. allocation-free, thread safe linear combinations for the above with a given set of coefficients,
+5. using [static arrays](https://github.com/JuliaArrays/StaticArrays.jl) extensively to avoid allocation and unroll *some* loops.
+
+While there is some functionality in this package to *fit* approximations to existing functions, it is not ideal for that, as it was optimized for mapping a set of coefficients to residuals of functional equations at gridpoints.
+
+Also, while the package should interoperate seamlessly with most AD frameworks, only the derivative API (explained below) is guaranteed to have correct derivatives of limits near infinity.
+
+## Concepts
 
 In this package,
 
@@ -24,7 +34,7 @@ A basis is constructed using
 
 A set of coordinates for a particular basis can be augmented for a wider basis with [`augment_coefficients`](@ref).
 
-Currenly, all bases have the domain ``[-1,1]`` or ``[-1,1]^n``. Facilities are provided for coordinatewise *transformations* to other domains.
+Bases have a “canonical” domain, eg ``[-1,1]`` or ``[-1,1]^n`` for Chebyshev polynomials. Use [transformations](#domains-and-transformations) for mapping to other domains.
 
 ## Examples
 
@@ -88,7 +98,7 @@ transform_from
 domain
 ```
 
-    In most cases you do not need to specify a domain directly: transformations specify their domains (eg from ``(0, ∞)``), and the codomain is determined by a basis. However, the following can be used to construct and query some concrete domains.
+In most cases you do not need to specify a domain directly: transformations specify their domains (eg from ``(0, ∞)``), and the codomain is determined by a basis. However, the following can be used to construct and query some concrete domains.
 
 ```@docs
 domain_kind

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -57,9 +57,9 @@ function basis_at(basis::Chebyshev, x::Scalar)
     ChebyshevIterator(x, basis.N)
 end
 
-function Base.iterate(itr::ChebyshevIterator)
-    @unpack x = itr
-    _one(x), (2, _one(x), x)
+function Base.iterate(itr::ChebyshevIterator{T}) where T
+    (; x) = itr
+    _one(T), (2, _one(T), x)
 end
 
 function Base.iterate(itr::ChebyshevIterator{T}, (i, fp, fpp)) where T

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -78,8 +78,8 @@ $(SIGNATURES)
 
 Return a gridpoint for collocation, with `1 ≤ i ≤ dimension(basis)`.
 
-`T` is used *as a hint* for the element type of grid coordinates, and defaults to `Float64`.
-The actual type can be broadened as required. Methods are type stable.
+`T` is used *as a hint* for the element type of grid coordinates. The actual type can be
+broadened as required. Methods are type stable.
 
 !!! note
     Not all grids have this method defined, especially if it is impractical. See

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -2,25 +2,29 @@
 ##### Internal implementation for derivatives. See docs of [`Derivatives`](@ref).
 #####
 
-export derivatives
+export derivatives, ∂
+
+####
+#### derivatives API
+####
 
 """
 A small AD framework used *internally*, for calculating derivatives.
 
-Supports only the operations required by this module. The restriction is deliberate, should
-not be used for arithmetic operators outside this package.
+Supports only the operations required by this module. The restriction is deliberate,
+should not be used for arithmetic operators outside this package.
 
-See [`derivatives`](@ref).
+See [`derivatives`](@ref) for the exposed API.
 """
-struct Derivatives{I,N,T}
+struct Derivatives{N,T}
     "The function value and derivatives."
     derivatives::NTuple{N,T}
-    function Derivatives{I}(derivatives::NTuple{N,T}) where {I,N,T}
-        @argcheck I isa Int
-        @argcheck I ≥ 0
-        new{I,N,T}(derivatives)
+    function Derivatives(derivatives::NTuple{N,T}) where {N,T}
+        new{N,T}(derivatives)
     end
 end
+
+Base.eltype(::Type{Derivatives{N,T}}) where {N,T} = T
 
 @inline Base.getindex(x::Derivatives, i::Int) = x.derivatives[i + 1]
 
@@ -28,74 +32,33 @@ end
 const Scalar = Union{Real,Derivatives}
 
 """
-$(SIGNATURES)
+    derivatives(x, ::Val(N) = Val(1))
 
-The highest `I` in the arguments `Derivatives{I}`, wrapped in a `Val`. `J` gives the lower
-bound. Internal.
-"""
-_highest_tag(::Val{J}, x::Real, xs...) where {J} = _highest_tag(Val(J), xs...)
-
-function _highest_tag(::Val{J}, x::Derivatives{I}, xs...) where {J,I}
-    _highest_tag(Val(max(I,J)), xs...)
-end
-
-_highest_tag(::Val{J}) where {J} = Val(J)
-
-"""
-$(SIGNATURES)
-
-Map `xs` to increasing tags when `0`, starting at `J`.
-"""
-function _increasing_tags(::Val{J}, acc, x::Derivatives{I}, xs...) where {J,I}
-    if I == 0
-        _increasing_tags(Val(J + 1), (acc..., Derivatives{J+1}(x.derivatives)), xs...)
-    else
-        _increasing_tags(Val(J), (acc..., x), xs...)
-    end
-end
-
-function _increasing_tags(::Val{J}, acc, x::Real, xs...) where {J}
-    _increasing_tags(Val(J), (acc..., x), xs...)
-end
-
-_increasing_tags(::Val{J}, acc) where {J} = acc
-
-"""
-$(SIGNATURES)
-
-Replace zero tags with increasing numbers from left to right, starting after the highest tag
-in the argument.
-"""
-function replace_zero_tags(xs::Tuple)
-    _increasing_tags(_highest_tag(Val(0), xs...), (), xs...)
-end
-
-"""
-    derivatives(::Val(I) = Val(0), x, ::Val(N) = Val(1))
-
-Obtain `N` derivatives (and the function value) at a scalar `x`. The `i`th derivative can be
-accessed with `[i]` from results, with `[0]` for the function value.
-
-`I` is an integer “tag” for determining the nesting order. Lower `I` always end up outside
-when nested. When the defaults are used in multiple coordinates, increasing numbers replace
-zeros from left to right, starting after the highest explicitly assigned tag.
-
-Consequently, for most applications, you only need to specify tags if you want a different
-nesting than left-to-right.
+Obtain `N` derivatives (and the function value) at a scalar `x`. The `i`th derivative
+can be accessed with `[i]` from results, with `[0]` for the function value.
 
 # Important note about transformations
 
-Always use `derivatives` *before* a transformation for correct results. For example, for some
-transformation `I` and value `x` in the transformed domain,
+Always use `derivatives` *before* a transformation for correct results. For example, for
+some transformation `t` and value `x` in the transformed domain,
+
 ```julia
-basis_at(basis2, to_pm1(I, derivatives(x))) # right
-```
-instead of
-```julia
-basis_at(basis2, derivatives(to_pm1(I, x))) # WRONG
+# right
+linear_combination(basis, θ, transform_to(domain(basis), t, derivatives(x)))
+# right (convenience form)
+(linear_combination(basis, θ) ∘ t)(derivatives(x))
 ```
 
-# Univariate example
+instead of
+
+```julia
+# WRONG
+linear_combination(basis, θ, derivatives(transform_to(domain(basis), t, x)))
+```
+
+For multivariate calculations, use the [`∂`](@ref) interface.
+
+# Example
 
 ```jldoctest
 julia> basis = Chebyshev(InteriorGrid(), 3)
@@ -110,26 +73,127 @@ julia> C = collect(basis_at(basis, derivatives(0.1)))
 julia> C[1][1]                         # 1st derivative of the linear term is 1
 0.0
 ```
-
-# Multivariate example
-
-```jldoctest
-julia> basis = smolyak_basis(Chebyshev, InteriorGrid(), SmolyakParameters(2), 2)
-Sparse multivariate basis on ℝ²
-  Smolyak indexing, ∑bᵢ ≤ 2, all bᵢ ≤ 2, dimension 21
-  using Chebyshev polynomials (1st kind), InteriorGrid(), dimension: 9
-
-julia> C = collect(basis_at(basis, (derivatives(0.1), derivatives(0.2, Val(2)))));
-
-julia> C[14][1][2]                  # ∂/∂x₁ ∂/∂x₂² of the 14th basis function at x
-4.0
-```
 """
-function derivatives(::Val{I}, x::T, ::Val{N} = Val(1)) where {I, N, T <: Real}
-    Derivatives{I}((x, ntuple(i -> i == 1 ? one(T) : zero(T), Val(N))...))
+function derivatives(x::T, ::Val{N} = Val(1)) where {N, T <: Real}
+    Derivatives((x, ntuple(i -> i == 1 ? one(T) : zero(T), Val(N))...))
 end
 
-derivatives(x::Real, ::Val{N} = Val(1)) where {N} = derivatives(Val(0), x, Val(N))
+####
+#### partial derivatives API
+####
+
+struct PartialDerivatives{M,L}
+    lookups::L
+    function PartialDerivatives{M}(lookups::L) where {M,L}
+        @argcheck M isa Tuple{Vararg{Int}}
+        @argcheck !isempty(lookups)
+        @argcheck lookups isa Tuple{Vararg{typeof(M)}}
+        new{M,L}(lookups)
+    end
+end
+
+function Base.show(io::IO, partial_derivatives::PartialDerivatives)
+    (; lookups) = partial_derivatives
+    print(io, "partial derivatives")
+    for (j, lookup) in enumerate(lookups)
+        print(io, "\n[$j] ")
+        if all(iszero, lookup)
+            print(io, "f")
+        else
+            s = sum(lookup)
+            print(io, "∂")
+            s ≠ 1 && print(io, SuperScript(s))
+            print(io, "f/")
+            for (i, l) in enumerate(lookup)
+                l == 0 && continue # don't print ∂⁰
+                print(io, "∂")
+                if l ≠ 1
+                    print(io, SuperScript(l))
+                end
+                print(io, "x", SubScript(i))
+            end
+        end
+    end
+end
+
+function _partial_to_lookup(::Val{D}, partial::Tuple{Vararg{Int}}) where D
+    @argcheck all(p -> 0 < p ≤ D, partial)
+    ntuple(d -> sum(p -> p == d, partial; init = 0), Val(D))
+end
+
+"""
+$(SIGNATURES)
+
+Partial derivative specification. The first argument is `Val(::Int)` or simply an `Int`
+(for convenience, using constant folding), determining the dimension of the argument.
+
+Subsequent arguments are indices of the input variable.
+
+```jldoctest
+julia> ∂(3, (), (1, 1), (2, 3))
+partial derivatives
+[1] f
+[2] ∂²f/∂²x₁
+[3] ∂²f/∂x₂∂x₃
+```
+"""
+@inline function ∂(::Val{D}, partials...) where D
+    @argcheck D ≥ 1 "Needs at least one dimension."
+    @argcheck !isempty(partials) "Empty partial derivative specification."
+    lookups = map(p -> _partial_to_lookup(Val(D), p), partials)
+    M = ntuple(d -> maximum(l -> l[d], lookups), Val(D))
+    PartialDerivatives{M}(lookups)
+end
+
+@inline ∂(D::Integer, partials...) = ∂(Val(D), partials...)
+
+struct PartialDerivativesAt{TX<:SVector,TP<:PartialDerivatives}
+    x::TX
+    partial_derivatives::TP
+    function PartialDerivativesAt(x::TX, partial_derivatives::TP) where {N,M,TX<:SVector{N},TP<:PartialDerivatives{M}}
+        @argcheck length(M) == N
+        new{TX,TP}(partial_derivatives, x)
+    end
+end
+
+@inline function ∂(x::SVector{N}, partials...) where N
+    PD = PartialDerivatives(Val{N}, partials...)
+    PartialDerivativesAt(x, PD)
+end
+
+####
+#### products (used by tensor / Smolyak bases)
+####
+
+"""
+$(SIGNATURES)
+
+Conceptually equivalent to `prod(getindex.(sources, indices))`, which it returns when
+`kind` is `nothing`, a placeholder calculating any derivatives.
+"""
+_product(kind::Nothing, sources, indices) = mapreduce(getindex, *, sources, indices)
+
+"""
+$(SIGNATURES)
+
+Type that is returnedby [`_product`](@ref).
+"""
+function _product_type(::Type{Nothing}, source_eltypes)
+    mapfoldl(eltype, promote_type, source_eltypes)
+end
+
+function _product(partial_derivatives::PartialDerivatives, sources, indices)
+    (; lookups) = partial_derivatives
+    map(lookups) do lookup
+        mapreduce((l, s, i) -> s[i][l], *, lookup, sources, indices)
+    end
+end
+
+function _product_type(::Type{PartialDerivatives{M,L}}, source_eltypes) where {M,L}
+    T = _product_type(nothing, source_eltypes)
+    N = length(fieldtypes(L))
+    NTuple{N,T}
+end
 
 ####
 #### operations we support
@@ -156,74 +220,38 @@ _mul(x, y, z) = _mul(_mul(x, y), z)
 
 _div(x::Real, y::Real) = x / y
 
-function _one(::Type{Derivatives{I,N,T}}) where {I,N,T}
-    Derivatives{I}(ntuple(i -> i == 1 ? _one(T) : _zero(T), Val(N)))
+function _one(::Type{Derivatives{N,T}}) where {N,T}
+    Derivatives(ntuple(i -> i == 1 ? _one(T) : _zero(T), Val(N)))
 end
 
-function _add(x::Derivatives{I}, y::Derivatives{I}) where {I}
-    Derivatives{I}(map(_add, x.derivatives, y.derivatives))
+function _add(x::Derivatives, y::Derivatives)
+    Derivatives(map(_add, x.derivatives, y.derivatives))
 end
 
-function _sub(x::Derivatives{I}, y::Real) where {I}
+function _sub(x::Derivatives, y::Real)
     x1, xrest... = x.derivatives
-    Derivatives{I}((x1 - y, xrest...))
+    Derivatives((x1 - y, xrest...))
 end
 
-function _sub(x::Derivatives{I}, y::Derivatives{I}) where {I}
-    Derivatives{I}(map(_sub, x.derivatives, y.derivatives))
+function _sub(x::Derivatives, y::Derivatives)
+    Derivatives(map(_sub, x.derivatives, y.derivatives))
 end
 
-function _mul(x::Real, y::Derivatives{I}) where {I}
-    Derivatives{I}(map(y -> _mul(x, y), y.derivatives))
+function _mul(x::Real, y::Derivatives)
+    Derivatives(map(y -> _mul(x, y), y.derivatives))
 end
 
-function _div(x::Derivatives{I}, y::Real) where {I}
-    Derivatives{I}(map(x -> _div(x, y), x.derivatives))
+function _div(x::Derivatives, y::Real)
+    Derivatives(map(x -> _div(x, y), x.derivatives))
 end
 
-@generated function _mul(x::Derivatives{I,N}, y::Derivatives{I,N}) where {I,N}
+@generated function _mul(x::Derivatives{N}, y::Derivatives{N}) where {N}
     _sum_terms(k) = mapreduce(i -> :(_mul($(binomial(k, i)), xd[$(i + 1)], yd[$(k - i + 1)])),
                               (a, b) -> :(_add($(a), $(b))), 0:k)
     _derivatives(k) = mapfoldl(_sum_terms, (a, b) -> :($(a)..., $(b)), 0:(N-1); init = ())
     quote
         xd = x.derivatives
         yd = y.derivatives
-        Derivatives{$(I)}($(_derivatives(N)))
+        Derivatives($(_derivatives(N)))
     end
-end
-
-function _nesting_mul(x::Derivatives{I}, y::Derivatives) where {I}
-    Derivatives{I}(map(x -> _mul(x, y), x.derivatives))
-end
-
-function _mul(x::Derivatives{I1},y::Derivatives{I2}) where {I1,I2}
-    @argcheck I1 ≠ I2
-    @argcheck I1 > 0 && I2 > 0 "Can't nest derivatives with zero tags."
-    if I1 < I2
-        _nesting_mul(x, y)
-    else
-        _nesting_mul(y, x)
-    end
-end
-
-function _mul_type(::Type{T1}, ::Type{T2}) where {T1<:Real,T2<:Real}
-    promote_type(T1, T2)
-end
-
-function _mul_type(::Type{Derivatives{I1,N1,T1}},
-                   ::Type{Derivatives{I2,N2,T2}}) where {I1,N1,T1,I2,N2,T2}
-    if I1 < I2
-        Derivatives{I1,N1,Derivatives{I2,N2,_mul_type(T1, T2)}}
-    else
-        Derivatives{I2,N2,Derivatives{I1,N1,_mul_type(T1, T2)}}
-    end
-end
-
-function _mul_type(::Type{Derivatives{I1,N1,T1}},
-                   ::Type{T2}) where {I1,N1,T1,T2<:Real}
-    Derivatives{I1,N1,_mul_type(T1, T2)}
-end
-
-function _mul_type(S1::Type{<:Real}, S2::Type{<:Derivatives})
-    _mul_type(S2, S1)
 end

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -324,22 +324,10 @@ end
 #### operators.
 ####
 
-_zero(::Type{T}) where {T<:Real} = zero(T)
-
-function _zero(::Type{Derivatives{N,T}}) where {N,T}
-    z = _zero(T)
-    Derivatives(ntuple(_ -> z, Val(N)))
-end
-
-function _zero(::Type{∂Output{N,T}}) where {N,T}
-    z = zero(T)
-    ∂Output(ntuple(_ -> z, Val(N)))
-end
-
 _one(::Type{T}) where {T<:Real} = one(T)
 
 function _one(::Type{Derivatives{N,T}}) where {N,T}
-    Derivatives(ntuple(i -> i == 1 ? _one(T) : _zero(T), Val(N)))
+    Derivatives(ntuple(i -> i == 1 ? _one(T) : zero(T), Val(N)))
 end
 
 _add(x::Real, y::Real) = x + y
@@ -352,16 +340,7 @@ function _add(x::∂Output, y::∂Output)
     ∂Output(map(+, x.values, y.values))
 end
 
-function _add(x::Derivatives, y::Real)
-    Derivatives(map(x -> x + y, x.derivatives))
-end
-
 _sub(x::Real, y::Real) = x - y
-
-function _sub(x::Derivatives, y::Real)
-    x1, xrest... = x.derivatives
-    Derivatives((x1 - y, xrest...))
-end
 
 function _sub(x::Derivatives, y::Derivatives)
     Derivatives(map(_sub, x.derivatives, y.derivatives))
@@ -374,8 +353,6 @@ _mul(x, y, z) = _mul(_mul(x, y), z)
 function _mul(x::Real, y::Derivatives)
     Derivatives(map(y -> _mul(x, y), y.derivatives))
 end
-
-_mul(x::Real, y::Tuple) = map(y -> _mul(x, y), y)
 
 _mul(x::Real, y::∂Output) = ∂Output(map(y -> _mul(x, y), y.values))
 

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -24,6 +24,15 @@ struct Derivatives{N,T}
     end
 end
 
+function Base.show(io::IO, x::Derivatives)
+    for (i, d) in enumerate(x.derivatives)
+        i ≠ 1 && print(io, " + ")
+        print(io, d)
+        i ≥ 2 && print(io, "⋅Δ")
+        i ≥ 3 && print(io, SuperScript(i - 1))
+    end
+end
+
 Base.eltype(::Type{Derivatives{N,T}}) where {N,T} = T
 
 @inline Base.getindex(x::Derivatives, i::Int) = x.derivatives[i + 1]
@@ -65,10 +74,10 @@ julia> basis = Chebyshev(InteriorGrid(), 3)
 Chebyshev polynomials (1st kind), InteriorGrid(), dimension: 3
 
 julia> C = collect(basis_at(basis, derivatives(0.1)))
-3-element Vector{SpectralKit.Derivatives{0, 2, Float64}}:
- SpectralKit.Derivatives{0, 2, Float64}((1.0, 0.0))
- SpectralKit.Derivatives{0, 2, Float64}((0.1, 1.0))
- SpectralKit.Derivatives{0, 2, Float64}((-0.98, 0.4))
+3-element Vector{SpectralKit.Derivatives{2, Float64}}:
+ 1.0 + 0.0⋅Δ
+ 0.1 + 1.0⋅Δ
+ -0.98 + 0.4⋅Δ
 
 julia> C[1][1]                         # 1st derivative of the linear term is 1
 0.0
@@ -82,6 +91,18 @@ end
 #### partial derivatives API
 ####
 
+"""
+A specification for partial derivatives. Each element of `lookup` is an N-dimensional
+tuple, the elements of which determine the order of the derivative along that
+coordinate, eg `(1, 2, 0)` means 1st derivative along coordinate 1, 2nd derivative along
+coordinate 2.
+
+The elementwise maximum is stored in `M`. It is a type parameter because it needs to be
+available as such for `derivatives`. The implementation than calculates derivatives
+along coordinates, and combines them according to `lookups`.
+
+Internal.
+"""
 struct PartialDerivatives{M,L}
     lookups::L
     function PartialDerivatives{M}(lookups::L) where {M,L}
@@ -116,9 +137,18 @@ function Base.show(io::IO, partial_derivatives::PartialDerivatives)
     end
 end
 
-function _partial_to_lookup(::Val{D}, partial::Tuple{Vararg{Int}}) where D
-    @argcheck all(p -> 0 < p ≤ D, partial)
-    ntuple(d -> sum(p -> p == d, partial; init = 0), Val(D))
+"""
+$(SIGNATURES)
+
+Convert a partial specification to a lookup, for `N`-dimensional arguments. Eg
+```jldoctest
+julia> SpectralKit._partial_to_lookup(Val(3), (1, 3, 1))
+(2, 0, 1)
+```
+"""
+function _partial_to_lookup(::Val{N}, partial::Tuple{Vararg{Int}}) where N
+    @argcheck all(p -> 0 < p ≤ N, partial)
+    ntuple(d -> sum(p -> p == d, partial; init = 0), Val(N))
 end
 
 """
@@ -137,28 +167,96 @@ partial derivatives
 [3] ∂²f/∂x₂∂x₃
 ```
 """
-@inline function ∂(::Val{D}, partials...) where D
-    @argcheck D ≥ 1 "Needs at least one dimension."
+@inline function ∂(::Val{N}, partials...) where N
+    @argcheck N ≥ 1 "Needs at least one dimension."
     @argcheck !isempty(partials) "Empty partial derivative specification."
-    lookups = map(p -> _partial_to_lookup(Val(D), p), partials)
-    M = ntuple(d -> maximum(l -> l[d], lookups), Val(D))
+    lookups = map(p -> _partial_to_lookup(Val(N), p), partials)
+    M = ntuple(d -> maximum(l -> l[d], lookups), Val(N))
     PartialDerivatives{M}(lookups)
 end
 
-@inline ∂(D::Integer, partials...) = ∂(Val(D), partials...)
+@inline ∂(N::Integer, partials...) = ∂(Val(Int(N)), partials...)
 
-struct PartialDerivativesAt{TX<:SVector,TP<:PartialDerivatives}
+"""
+Partial derivatives to be evaluated at some `x`. These need to be [`_lift`](@ref)ed,
+then combined with [`_product`](@ref) from bases. Internal.
+"""
+struct PartialDerivativesAt{TD<:PartialDerivatives,TX<:SVector}
+    D::TD
     x::TX
-    partial_derivatives::TP
-    function PartialDerivativesAt(x::TX, partial_derivatives::TP) where {N,M,TX<:SVector{N},TP<:PartialDerivatives{M}}
+    function PartialDerivativesAt(partial_derivatives::TD,
+                                  x::TX) where {M,N,TD<:PartialDerivatives{M},TX<:SVector{N}}
         @argcheck length(M) == N
-        new{TX,TP}(partial_derivatives, x)
+        new{TD,TX}(partial_derivatives, x)
     end
 end
 
+function Base.show(io::IO, Dx::PartialDerivativesAt)
+    show(io, Dx.D)
+    print(io, "\nat ", Dx.x)
+end
+
+"""
+$(SIGNATURES)
+
+Partial derivatives `D` at `x`.
+```jldoctest
+julia> using StaticArrays
+
+julia> D = ∂(Val(2), (), (1,), (2,), (1, 2))
+partial derivatives
+[1] f
+[2] ∂f/∂x₁
+[3] ∂f/∂x₂
+[4] ∂²f/∂x₁∂x₂
+
+julia> ∂(D, SVector(1, 2))
+partial derivatives
+[1] f
+[2] ∂f/∂x₁
+[3] ∂f/∂x₂
+[4] ∂²f/∂x₁∂x₂
+at [1, 2]
+```
+"""
+function ∂(D::PartialDerivatives{M}, x::Union{AbstractVector,Tuple}) where M
+    N = length(M)
+    PartialDerivativesAt(D, SVector{N}(x))
+end
+
+"""
+$(SIGNATURES)
+
+Shorthand for `∂(x, ∂(Val(length(x)), partials...))`. Ideally needs an `SVector` or a
+`Tuple` so that size information can be obtained statically.
+"""
 @inline function ∂(x::SVector{N}, partials...) where N
-    PD = PartialDerivatives(Val{N}, partials...)
-    PartialDerivativesAt(x, PD)
+    D = ∂(Val(N), partials...)
+    PartialDerivativesAt(D, x)
+end
+
+@inline ∂(x::Tuple, partials...) = ∂(SVector(x), partials...)
+
+"""
+See [`_lift`](@ref). Internal.
+"""
+struct LiftedPartialDerivativesAt{TD<:PartialDerivatives,TL<:Tuple}
+    D::TD
+    lifted_x::TL
+end
+
+"""
+$(SIGNATURES)
+
+Lift a partial derivative calculation into a tuple of `Derivatives`. Internal.
+"""
+@generated function _lift(Dx::PartialDerivativesAt{<:PartialDerivatives{M}}) where M
+    _lifted_x = [:(derivatives(x[$(i)], Val($(m)))) for (i, m) in enumerate(M)]
+    quote
+        x = Dx.x
+        lifted_x = ($(_lifted_x...),)
+        LiftedPartialDerivativesAt(Dx.D, lifted_x)
+    end
 end
 
 ####
@@ -169,7 +267,7 @@ end
 $(SIGNATURES)
 
 Conceptually equivalent to `prod(getindex.(sources, indices))`, which it returns when
-`kind` is `nothing`, a placeholder calculating any derivatives.
+`kind` is `nothing`, a placeholder calculating any derivatives. Internal.
 """
 _product(kind::Nothing, sources, indices) = mapreduce(getindex, *, sources, indices)
 
@@ -190,7 +288,7 @@ function _product(partial_derivatives::PartialDerivatives, sources, indices)
 end
 
 function _product_type(::Type{PartialDerivatives{M,L}}, source_eltypes) where {M,L}
-    T = _product_type(nothing, source_eltypes)
+    T = _product_type(Nothing, map(eltype, source_eltypes))
     N = length(fieldtypes(L))
     NTuple{N,T}
 end
@@ -228,6 +326,8 @@ function _add(x::Derivatives, y::Derivatives)
     Derivatives(map(_add, x.derivatives, y.derivatives))
 end
 
+_add(x::NTuple{N}, y::NTuple{N}) where N = map(_add, x, y)
+
 function _sub(x::Derivatives, y::Real)
     x1, xrest... = x.derivatives
     Derivatives((x1 - y, xrest...))
@@ -240,6 +340,8 @@ end
 function _mul(x::Real, y::Derivatives)
     Derivatives(map(y -> _mul(x, y), y.derivatives))
 end
+
+_mul(x::Real, y::Tuple) = map(y -> _mul(x, y), y)
 
 function _div(x::Derivatives, y::Real)
     Derivatives(map(x -> _div(x, y), x.derivatives))

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -316,14 +316,16 @@ _mul(x::Real, y::Real) = x * y
 
 _mul(x, y, z) = _mul(_mul(x, y), z)
 
-_div(x::Real, y::Real) = x / y
-
 function _one(::Type{Derivatives{N,T}}) where {N,T}
     Derivatives(ntuple(i -> i == 1 ? _one(T) : _zero(T), Val(N)))
 end
 
 function _add(x::Derivatives, y::Derivatives)
     Derivatives(map(_add, x.derivatives, y.derivatives))
+end
+
+function _add(x::Derivatives, y::Real)
+    Derivatives(map(x -> x + y, x.derivatives))
 end
 
 _add(x::NTuple{N}, y::NTuple{N}) where N = map(_add, x, y)
@@ -342,10 +344,6 @@ function _mul(x::Real, y::Derivatives)
 end
 
 _mul(x::Real, y::Tuple) = map(y -> _mul(x, y), y)
-
-function _div(x::Derivatives, y::Real)
-    Derivatives(map(x -> _div(x, y), x.derivatives))
-end
 
 @generated function _mul(x::Derivatives{N}, y::Derivatives{N}) where {N}
     _sum_terms(k) = mapreduce(i -> :(_mul($(binomial(k, i)), xd[$(i + 1)], yd[$(k - i + 1)])),

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -87,8 +87,7 @@ end
 function Base.show(io::IO, domain::CoordinateDomains)
     (; domains) = domain
     if allequal(domains)
-        print(io, domains[1])
-        print_unicode_superscript(io, length(domains))
+        print(io, domains[1], SuperScript(length(domains)))
     else
         join(io, domains, "×")
     end

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -56,6 +56,15 @@ end
 
 Base.extrema(domain::UnivariateDomain) = (domain.min, domain.max)
 
+function Base.show(io::IO, domain::UnivariateDomain)
+    mi, ma = extrema(domain)
+    print(io, "[")
+    mi == -Inf ? print(io, "-∞") : print(io, mi)
+    print(io, ",")
+    ma == Inf ? print(io, "∞") : print(io, ma)
+    print(io, "]")
+end
+
 """
 Represents the interval ``[-1, 1]``.
 

--- a/src/generic_api.jl
+++ b/src/generic_api.jl
@@ -203,8 +203,6 @@ Equivalent to an `EndpointGrid` with endpoints dropped.
 """
 struct InteriorGrid2 <: AbstractGrid end
 
-gridpoint(basis, i) = gridpoint(Float64, basis, i)
-
 """
 `$(FUNCTIONNAME)([T], basis)`
 

--- a/src/smolyak_api.jl
+++ b/src/smolyak_api.jl
@@ -246,16 +246,15 @@ function basis_at(smolyak_basis::SmolyakBasis{<:SmolyakIndices{N}},
 end
 
 function basis_at(smolyak_basis::SmolyakBasis{<:SmolyakIndices{N}},
-                  Lx::LiftedPartialDerivativesAt) where {N}
-    (; D, lifted_x) = Lx
+                  Lx::∂InputLifted) where {N}
+    (; ∂specification, lifted_x) = Lx
     @argcheck length(lifted_x) == N
     @unpack smolyak_indices = smolyak_basis
-    SmolyakProduct(smolyak_indices, _univariate_bases_at(smolyak_basis, lifted_x), D)
+    SmolyakProduct(smolyak_indices, _univariate_bases_at(smolyak_basis, lifted_x),
+                   ∂specification)
 end
 
-function basis_at(smolyak_basis::SmolyakBasis, Dx::PartialDerivativesAt)
-    basis_at(smolyak_basis, _lift(Dx))
-end
+basis_at(smolyak_basis::SmolyakBasis, ∂x::∂Input) = basis_at(smolyak_basis, _lift(∂x))
 
 struct SmolyakGridIterator{T,I,S}
     smolyak_indices::I

--- a/src/smolyak_api.jl
+++ b/src/smolyak_api.jl
@@ -114,45 +114,45 @@ end
 #### product traversal
 ####
 
-struct SmolyakProduct{I<:SmolyakIndices,S<:Tuple}
+struct SmolyakProduct{I<:SmolyakIndices,S<:Tuple,P}
     smolyak_indices::I
     sources::S
+    product::P
     @doc """
     $(SIGNATURES)
 
-    An iterator equivalent to
+    An iterator conceptually equivalent to
 
     ```
     [prod(getindex.(sources, indices)) for indices in smolyak_indices]
     ```
 
-    implemented to perform the minimal number of multiplications. Detailed docs of the
+    using [`_product`](@ref) instead to account for derivatives. Detailed docs of the
     arguments are in [`SmolyakIndices`](@ref).
 
     Caller should arrange the elements of `sources` in the correct order, see
     [`nested_extrema_indices`](@ref). Each element in `sources` should have at least
     `H` elements (cf type parameters of [`SmolyakIndices`](@ref)), this is not checked.
     """
-    function SmolyakProduct(smolyak_indices::SmolyakIndices{N},
-                            sources::S) where {N,S}
+    function SmolyakProduct(smolyak_indices::I, sources::S,
+                            product::P) where {N,I<:SmolyakIndices{N},S,P}
         @argcheck length(sources) == N
-        new{typeof(smolyak_indices),S}(smolyak_indices, sources)
+        new{I,S,P}(smolyak_indices, sources)
     end
 end
 
 Base.length(smolyak_product::SmolyakProduct) = length(smolyak_product.smolyak_indices)
 
-@generated function Base.eltype(::Type{SmolyakProduct{I,S}}) where {I,S}
-    T = mapfoldl(eltype, _mul_type, fieldtypes(S))
-    :($T)
+function Base.eltype(::Type{SmolyakProduct{I,S,P}}) where {I,S,P}
+    _product_type(P, fieldtypes(S))
 end
 
 @inline function Base.iterate(smolyak_product::SmolyakProduct, state...)
-    @unpack smolyak_indices, sources = smolyak_product
+    (; smolyak_indices, sources, product) = smolyak_product
     itr = iterate(smolyak_indices, state...)
     itr ≡ nothing && return nothing
     indices, state′ = itr
-    reduce(_mul, getindex.(sources, indices)), state′
+    _product(product, sources, indices), state′
 end
 
 struct SmolyakBasis{I<:SmolyakIndices,U<:UnivariateBasis} <: MultivariateBasis
@@ -162,9 +162,8 @@ end
 
 function Base.show(io::IO, smolyak_basis::SmolyakBasis{<:SmolyakIndices{N}}) where N
     @unpack smolyak_indices, univariate_parent = smolyak_basis
-    print(io, "Sparse multivariate basis on ℝ")
-    print_unicode_superscript(io, N)
-    print(io, "\n  ", smolyak_indices, "\n  using ", univariate_parent)
+    print(io, "Sparse multivariate basis on ℝ", SuperScript(N), "\n  ", smolyak_indices,
+          "\n  using ", univariate_parent)
 end
 
 """
@@ -227,14 +226,32 @@ end
 
 dimension(smolyak_basis::SmolyakBasis) = length(smolyak_basis.smolyak_indices)
 
-function basis_at(smolyak_basis::SmolyakBasis{<:SmolyakIndices{N,H}}, x) where {N,H}
+function basis_at(smolyak_basis::SmolyakBasis{<:SmolyakIndices{N,H}},
+                  x::Union{Tuple,AbstractVector}) where {N,H}
     @argcheck length(x) == N
     @unpack smolyak_indices, univariate_parent = smolyak_basis
     function _f(x)
         sacollect(SVector{H}, basis_at(univariate_parent, x))
     end
-    univariate_bases_at = map(_f, replace_zero_tags(Tuple(x)))
-    SmolyakProduct(smolyak_indices, univariate_bases_at)
+    univariate_bases_at = map(_f, NTuple{N}(x))
+    SmolyakProduct(smolyak_indices, univariate_bases_at, nothing)
+end
+
+function _lift(::Val{H}, univariate_parent, partial_derivatives::PartialDerivatives{M},
+               x::SVector) where {H,M}
+    map((m, x) -> sacollect(SVector{H},
+                            basis_at(univariate_parent, derivative(x, Val(m)))),
+        M, Tuple(x)) # FIXME may need a generated function
+end
+
+
+function basis_at(smolyak_basis::SmolyakBasis{<:SmolyakIndices{N,H}},
+                  ∂x::PartialDerivativesAt) where {N,H}
+    (; partial_derivatives, x) = ∂x
+    @argcheck length(x) == N
+    @unpack smolyak_indices, univariate_parent = smolyak_basis
+    univariate_bases_at = _lift(Val(H), univariate_parent, partial_derivatives, x)
+    SmolyakProduct(smolyak_indices, univariate_bases_at, partial_derivatives)
 end
 
 struct SmolyakGridIterator{T,I,S}

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -114,6 +114,17 @@ function transform_to(domain::CoordinateDomains, ct::CoordinateTransformations,
     SVector(transform_to(domain, ct, Tuple(x)))
 end
 
+function transform_to(domain::CoordinateDomains, ct::CoordinateTransformations,
+                      x::PartialDerivativesAt)
+    transform_to(domain, ct, _lift(x))
+end
+
+function transform_to(domain::CoordinateDomains, ct::CoordinateTransformations,
+                      x::LiftedPartialDerivativesAt)
+    (; D, lifted_x) = x
+    LiftedPartialDerivativesAt(D, transform_to(domain, ct, lifted_x))
+end
+
 function transform_from(domain::CoordinateDomains, ct::CoordinateTransformations, x::Tuple)
     @unpack domains = domain
     @unpack transformations = ct

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -114,15 +114,14 @@ function transform_to(domain::CoordinateDomains, ct::CoordinateTransformations,
     SVector(transform_to(domain, ct, Tuple(x)))
 end
 
-function transform_to(domain::CoordinateDomains, ct::CoordinateTransformations,
-                      x::PartialDerivativesAt)
-    transform_to(domain, ct, _lift(x))
+function transform_to(domain::CoordinateDomains, ct::CoordinateTransformations, ∂x::∂Input)
+    transform_to(domain, ct, _lift(∂x))
 end
 
 function transform_to(domain::CoordinateDomains, ct::CoordinateTransformations,
-                      x::LiftedPartialDerivativesAt)
-    (; D, lifted_x) = x
-    LiftedPartialDerivativesAt(D, transform_to(domain, ct, lifted_x))
+                      ∂x::∂InputLifted)
+    (; ∂specification, lifted_x) = ∂x
+    ∂InputLifted(∂specification, transform_to(domain, ct, lifted_x))
 end
 
 function transform_from(domain::CoordinateDomains, ct::CoordinateTransformations, x::Tuple)
@@ -132,7 +131,8 @@ function transform_from(domain::CoordinateDomains, ct::CoordinateTransformations
     map((d, t, x) -> transform_from(d, t, x), domains, transformations, x)
 end
 
-function transform_from(domain::CoordinateDomains, ct::CoordinateTransformations, x::AbstractVector)
+function transform_from(domain::CoordinateDomains, ct::CoordinateTransformations,
+                        x::AbstractVector)
     SVector(transform_from(domain, ct, Tuple(x)))
 end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -7,13 +7,13 @@ $(SIGNATURES)
 
 Print a nonnegative number using `digits`, where `0` is indexed with `1`.
 """
-function print_number(io::IO, digits, k::Integer)
+function print_number(io::IO, DIGITS, k::Integer)
     @argcheck k ≥ 0
     if k < 10
-        print(io, digits[k + 1])
+        print(io, DIGITS[k + 1])
     else
-        for d in reverse(digits(l))
-            print(io, digits[d + 1])
+        for d in reverse(digits(k))
+            print(io, DIGITS[d + 1])
         end
     end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,17 +1,37 @@
 const _SUPERSCRIPT_DIGITS = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹']
 
+const _SUBSCRIPT_DIGITS = ['₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉']
+
 """
 $(SIGNATURES)
 
-Print a nonnegative integer with unicode superscript characters.
+Print a nonnegative number using `digits`, where `0` is indexed with `1`.
 """
-function print_unicode_superscript(io::IO, k::Integer)
-    @argcheck k > 0
+function print_number(io::IO, digits, k::Integer)
+    @argcheck k ≥ 0
     if k < 10
-        print(io, _SUPERSCRIPT_DIGITS[k + 1])
+        print(io, digits[k + 1])
     else
         for d in reverse(digits(l))
-            print(io, _SUPERSCRIPT_DIGITS[d + 1])
+            print(io, digits[d + 1])
         end
     end
 end
+
+"""
+Wrapper to `print` a nonnegative integer as superscript using Unicode.
+"""
+struct SuperScript
+    i::Int
+end
+
+Base.print(io::IO, s::SuperScript) = print_number(io, _SUPERSCRIPT_DIGITS, s.i)
+
+"""
+Wrapper to `print` a nonnegative integer as subscript using Unicode.
+"""
+struct SubScript
+    i::Int
+end
+
+Base.print(io::IO, s::SubScript) = print_number(io, _SUBSCRIPT_DIGITS, s.i)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Sobol = "ed01d8cd-4d21-5b2a-85b4-cc3bdc58bad4"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test, DocStringExtensions, StaticArrays, BenchmarkTools, FiniteDifferences
 
 include("utilities.jl")
 
+include("test_utilities.jl")
 include("test_domains.jl")
 include("test_derivatives.jl")
 include("test_transformations.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SpectralKit
 using SpectralKit: PM1
-using Test, DocStringExtensions, StaticArrays, BenchmarkTools, Sobol
+using Test, DocStringExtensions, StaticArrays, BenchmarkTools
 # import ForwardDiff
 
 include("utilities.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using SpectralKit
 using SpectralKit: PM1
-using Test, DocStringExtensions, StaticArrays, BenchmarkTools
-# import ForwardDiff
+using Test, DocStringExtensions, StaticArrays, BenchmarkTools, FiniteDifferences
 
 include("utilities.jl")
 
 include("test_domains.jl")
+include("test_derivatives.jl")
 include("test_transformations.jl")
 include("test_generic_api.jl")
 include("test_chebyshev.jl")

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1,4 +1,4 @@
-using SpectralKit: ∂Specification
+using SpectralKit: ∂Specification, ∂Output
 using SpectralKit: _add                           # used to form a scalar for testing
 using SpectralKit: Derivatives                    # test internals
 
@@ -7,23 +7,39 @@ using SpectralKit: Derivatives                    # test internals
     @test ∂(3, (), (1, 1, 2), (3, 2)) == ∂Specification{(2, 1, 1)}(((0, 0, 0),  (2, 1, 0), (0, 1, 1)))
     @test_throws ArgumentError ∂(3, (4, ))
     @test_throws ArgumentError ∂(3, (-1, ))
+    ∂spec = ∂(2, (1, 2), (2, 2))
+    @test repr(∂spec) == "partial derivatives\n[1] ∂²f/∂x₁∂x₂\n[2] ∂²f/∂²x₂"
+    @test repr(∂(∂spec, [1.0, 2.0])) ==
+        "partial derivatives\n[1] ∂²f/∂x₁∂x₂\n[2] ∂²f/∂²x₂\nat [1.0, 2.0]"
+    @test ∂((1.0, 2.0), (1, 2)) ≡ ∂(SVector(1.0, 2.0), (1, 2)) ≡ ∂(∂(Val(2), (1, 2)), (1.0, 2.0))
+    ∂o = ∂Output((1.0, 2.0))
+    @test repr(∂o) == "SpectralKit.∂Output(1.0, 2.0)"
+    @test ∂o[1] == 1.0
+    @test length(∂o) == 2
+    @test Tuple(∂o) == (1.0, 2.0)
 end
 
-# @testset "univariate derivatives check" begin
-#     z = 0.6
-#     x = derivatives(z, Val(2))
-#     @test x[0] == z
-#     @test x[1] == 1
-#     @test x[2] == 0
-#     b = Chebyshev(EndpointGrid(), 4)
-#     f(z) = sum(basis_at(b, z))
-#     bz = basis_at(b, derivatives(z, Val(2)))
-#     iterator_sanity_checks(bz)
-#     ∑b = reduce(_add, bz)
-#     @test ∑b[0] ≈ f(z)
-#     @test ∑b[1] ≈ DD(f, z) atol = 1e-8
-#     @test ∑b[2] ≈ DD(f, z, 2) atol = 1e-8
-# end
+@testset "univariate derivatives check" begin
+    z = 0.6
+    x = derivatives(z, Val(2))
+    @test x[0] == z
+    @test x[1] == 1
+    @test x[2] == 0
+    b = Chebyshev(EndpointGrid(), 4)
+    f(z) = sum(basis_at(b, z))
+    bz = basis_at(b, derivatives(z, Val(2)))
+    iterator_sanity_checks(bz)
+    ∑b = reduce(_add, bz)
+    @test ∑b[0] ≈ f(z)
+    @test ∑b[1] ≈ DD(f, z) atol = 1e-8
+    @test ∑b[2] ≈ DD(f, z, 2) atol = 1e-8
+end
+
+@testset "univariate derivatives sanity checks" begin
+    d = derivatives(0.5, Val(2))
+    @test eltype(d) ≡ Float64
+    @test repr(d) == "0.5 + 1.0⋅Δ + 0.0⋅Δ²"
+end
 
 @testset "univariate transformed derivatives" begin
     D = 1                       # derivatives up to this one

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1,10 +1,10 @@
-using SpectralKit: PartialDerivatives
+using SpectralKit: ∂Specification
 using SpectralKit: _add                           # used to form a scalar for testing
 using SpectralKit: Derivatives                    # test internals
 
 @testset "partial derivatives interface" begin
-    @test ∂(2, (1, 2), (2, 2)) == PartialDerivatives{(1, 2)}(((1, 1), (0, 2)))
-    @test ∂(3, (), (1, 1, 2), (3, 2)) == PartialDerivatives{(2, 1, 1)}(((0, 0, 0),  (2, 1, 0), (0, 1, 1)))
+    @test ∂(2, (1, 2), (2, 2)) == ∂Specification{(1, 2)}(((1, 1), (0, 2)))
+    @test ∂(3, (), (1, 1, 2), (3, 2)) == ∂Specification{(2, 1, 1)}(((0, 0, 0),  (2, 1, 0), (0, 1, 1)))
     @test_throws ArgumentError ∂(3, (4, ))
     @test_throws ArgumentError ∂(3, (-1, ))
 end

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1,5 +1,14 @@
+using SpectralKit: PartialDerivatives
 using SpectralKit: _add                           # used to form a scalar for testing
 using SpectralKit: Derivatives, replace_zero_tags # test internals
+
+@testset "partial derivatives interface" begin
+    @test ∂(2, (1, 2), (2, 2)) == PartialDerivatives{(1, 2)}(((1, 1), (0, 2)))
+    @test ∂(3, (), (1, 1, 2), (3, 2)) == PartialDerivatives{(2, 1, 1)}(((0, 0, 0),  (2, 1, 0), (0, 1, 1)))
+    @test_throws ArgumentError ∂(3, (4, ))
+    @test_throws ArgumentError ∂(3, (-1, ))
+end
+
 
 @testset "univariate derivatives check" begin
     z = 0.6

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -46,7 +46,7 @@ end
 @testset "Smolyak derivatives check" begin
     N = 2
     b = smolyak_basis(Chebyshev, InteriorGrid(), SmolyakParameters(3), N)
-    t = coordinate_transformations((BoundedLinear(1.0, 2.7), BoundedLinear(-3.0, 2.0)))
+    t = coordinate_transformations((BoundedLinear(1.0, 2.7), SemiInfRational(3.0, 0.7)))
     D = ∂(Val(2), (), (1,), (2, ), (1, 2))
     D̃ = [(f, x) -> f(x),
          (f, x) -> DD(x1 -> f((x1, x[2])), x[1]),

--- a/test/test_domains.jl
+++ b/test/test_domains.jl
@@ -1,10 +1,16 @@
 @testset "domain API" begin
     d1 = SpectralKit.PM1()
+    @test repr(d1) == "[-1,1]"
     @test extrema(d1) == (-1, 1)
+    @test (minimum(d1), maximum(d1)) == extrema(d1)
     @test domain_kind(d1) ≡ :univariate
     dn = coordinate_domains(d1, d1)
+    @test dn == coordinate_domains((d1, d1)) == coordinate_domains(Val(2), d1)
+    @test repr(dn) == "[-1,1]²"
     @test domain_kind(dn) ≡ :multivariate
     @test length(dn) == 2
     @test dn[1] == d1
     @test Tuple(dn) ≡ (d1, d1)
+    d2 = coordinate_domains(SpectralKit.PM1(), SpectralKit.UnivariateDomain(-3.0, Inf))
+    @test repr(d2) == "[-1,1]×[-3.0,∞]"
 end

--- a/test/test_generic_api.jl
+++ b/test/test_generic_api.jl
@@ -41,3 +41,8 @@ end
         @test l1(transform_to(domain(basis), t, x)) == l2(x)
     end
 end
+
+@testset "subset fallback" begin
+    @test !is_subset_basis(Chebyshev(InteriorGrid(), 4), # just test the fallback method
+                           smolyak_basis(Chebyshev, InteriorGrid(), SmolyakParameters(2, 2), 2))
+end

--- a/test/test_smolyak.jl
+++ b/test/test_smolyak.jl
@@ -4,6 +4,10 @@ using SpectralKit: nesting_total_length, nesting_block_length, SmolyakIndices,
 "grids we test on"
 GRIDS = (EndpointGrid(), InteriorGrid(), InteriorGrid2())
 
+@testset "printing SmolyakParameters" begin
+    @test repr(SmolyakParameters(3, 2)) == "Smolyak parameters, ∑bᵢ ≤ 3, all bᵢ ≤ 2"
+end
+
 ####
 #### blocks
 ####

--- a/test/test_smolyak.jl
+++ b/test/test_smolyak.jl
@@ -104,7 +104,7 @@ end
                     ι = SmolyakIndices{N}(grid_kind, SmolyakParameters(B, M))
                     ℓ = nesting_total_length(Chebyshev, grid_kind, min(B,M))
                     sources = ntuple(_ -> rand(SVector{ℓ, Float64}), Val(N))
-                    P = SmolyakProduct(ι, sources)
+                    P = SmolyakProduct(ι, sources, nothing)
                     @test length(ι) == length(P)
                     @test eltype(P) == Float64
                     for (i, p) in zip(ι, P)

--- a/test/test_transformations.jl
+++ b/test/test_transformations.jl
@@ -78,11 +78,18 @@ end
     @test x2 isa SVector{2,Float64} && all(x2 .≈ x)
 end
 
-# FIXME uncomment if relevant, otherwise delete
-# @testset "partial application" begin
-#     t = SemiInfRational(7.0, 1.0)
-#     x = rand_pm1()
-#     y = from_pm1(t, x)
-#     @test from_pm1(t)(x) == y
-#     @test to_pm1(t)(y) == to_pm1(t, y)
-# end
+@testset "printing, promotion, broadcasting" begin
+    v = [1.0, 2.0]
+    t1 = BoundedLinear(2.0, 3)
+    @test repr(t1) == "(2.0,3.0) ↔ domain [linear transformation]"
+    @test transform_to.(PM1(), t1, v) isa Vector
+    t2 = SemiInfRational(7.0, 1)
+    @test repr(t2) == "(7.0,∞) ↔ domain [rational transformation with scale 1.0]"
+    @test transform_to.(PM1(), t2, v) isa Vector
+    t3 = InfRational(0.5, 1)
+    @test repr(t3) == "(-∞,∞) ↔ domain [rational transformation with center 0.5, scale 1.0]"
+    @test transform_to.(PM1(), t3, v) isa Vector
+    ct = coordinate_transformations(t1, t2, t3)
+    @test repr(ct) ==
+        "coordinate transformations\n  " * repr(t1) * "\n  " * repr(t2) * "\n  " * repr(t3)
+end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,0 +1,7 @@
+@testset "unicode printing" begin
+    i = 9876543210
+    io = IOBuffer()
+    print(io, SpectralKit.SubScript(i))
+    print(io, SpectralKit.SuperScript(i))
+    @test String(take!(io)) == "₉₈₇₆₅₄₃₂₁₀⁹⁸⁷⁶⁵⁴³²¹⁰"
+end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -67,27 +67,18 @@ function e_i(basis, i)
 end
 
 """
-$(SIGNATURES)
-
-Function and its derivative at `x`.
-"""
-f_f′(f, x) = f(x), ForwardDiff.derivative(f, x)
-
-"""
-Helper function for ``∂^N f/∂x^N``.
-"""
-function ddn(f, x, ::Val{N}) where {N}
-    fn = foldl((f, _) -> x -> ForwardDiff.derivative(f, x),
-               ntuple(_ -> nothing, Val(N)); init = f)
-    fn(x)
-end
-
-"""
-Sanity checks for iterators.
+Some sanity checks for iterators.
 """
 function iterator_sanity_checks(itr)
     T = eltype(typeof(itr))
     @test eltype(itr) ≡ T
     @test all(x -> typeof(x) ≡ T, itr)
     @test count(_ -> true, itr) == length(itr)
+end
+
+"Derivative of f at x."
+function DD(f, x, n = 1; p = 10)
+    # workaround for https://github.com/JuliaDiff/FiniteDifferences.jl/issues/224
+    # remove anonymous call when that is fixed
+    central_fdm(p, n)(x -> f(x), x)
 end


### PR DESCRIPTION
Replace the clumsy nested API with a partial derivatives operator.

Incidental: unicode printing changes.

# TODO

- [x] test `lift` for type stability, zero allocations, and correctness
- [x] implement at least first derivatives for rational transformations
- [x] correctness testing using finite differences, not ForwardDiff, for untransformed and 3 kinds of transformed bases, univariate and multivariate
- [x] finish documentation